### PR TITLE
Add new event types and a field containing the data from i3 in Event

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -22,6 +22,8 @@ const (
 	I3WorkspaceEvent EventType = iota
 	I3OutputEvent
 	I3ModeEvent
+	I3WindowEvent
+	I3BarConfigEvent
 	// private value used for setting up internal stuff in init()
 	// The idea is that if there's a new type of event added to i3, it only
 	// needs to be added here and in the payloads slice below, and the rest of
@@ -30,7 +32,7 @@ const (
 )
 
 // This slice is used to map event types to their string representation.
-var payloads []string = []string{"workspace", "output", "mode"}
+var payloads []string = []string{"workspace", "output", "mode", "window", "barconfig_update"}
 
 // Dynamically add an event type by defining a name for it. Just in case i3 adds
 // a new one and this library hasn't been updated yet. Returns the EventType


### PR DESCRIPTION
Adds the window and barconfig_update event types and a new field in Event which contains the rest of the data sent in the event message from i3.
