### PR TITLE
Return success for empty replies, fixes #3

### DIFF
--- a/command.go
+++ b/command.go
@@ -40,6 +40,11 @@ func (self *IPCSocket) Command(action string) (success bool, err error) {
 		return
 	}
 
+	if len(cmd_reply) == 0 {
+		success = true
+		return
+	}
+
 	success = cmd_reply[0].Success
 	if cmd_reply[0].Error == "" {
 		err = nil


### PR DESCRIPTION
i3 returns empty JSON arrays for workspace commands if the target workspace is currently focused:

```
% i3-msg workspace 3
[{"success":true}]
% i3-msg workspace 3
[]
```

Therefore, this pull request changes `Command` to report success for zero-length replies. This fixes issue #3.

I am not exactly a Go expert, so please let me know if this is too crude.
